### PR TITLE
feat(context): improve BrowserContextOptions constructor

### DIFF
--- a/src/PlaywrightSharp.Tests/Chromium/OopifTests.cs
+++ b/src/PlaywrightSharp.Tests/Chromium/OopifTests.cs
@@ -147,11 +147,12 @@ namespace PlaywrightSharp.Tests.Chromium
         [SkipBrowserAndPlatformFact(skipFirefox: true, skipWebkit: true)]
         public async Task ShouldSupportContextOptions()
         {
-            BrowserContextOptions contextOptions = Playwright.Devices["iPhone 6"];
-            contextOptions.TimezoneId = "America/Jamaica";
-            contextOptions.Locale = "fr-CH";
-            contextOptions.UserAgent = "UA";
-            await using var context = await _browser.NewContextAsync(contextOptions);
+            await using var context = await _browser.NewContextAsync(new BrowserContextOptions(Playwright.Devices["iPhone 6"])
+            {
+                TimezoneId = "America/Jamaica",
+                Locale = "fr-CH",
+                UserAgent = "UA",
+            });
             var page = await context.NewPageAsync();
 
             var (userAgent, _) = await TaskUtils.WhenAll(

--- a/src/PlaywrightSharp.Tests/Emulation/PageEmulateTests.cs
+++ b/src/PlaywrightSharp.Tests/Emulation/PageEmulateTests.cs
@@ -13,13 +13,11 @@ namespace PlaywrightSharp.Tests.Emulation
     public class PageEmulateTests : PlaywrightSharpBrowserBaseTest
     {
         private readonly BrowserContextOptions _iPhone;
-        private readonly BrowserContextOptions _iPhoneLandscape;
 
         /// <inheritdoc/>
         public PageEmulateTests(ITestOutputHelper output) : base(output)
         {
             _iPhone = Playwright.Devices["iPhone 6"];
-            _iPhoneLandscape = Playwright.Devices["iPhone 6 landscape"];
         }
 
         ///<playwright-file>emulation.spec.js</playwright-file>

--- a/src/PlaywrightSharp/BrowserContextOptions.cs
+++ b/src/PlaywrightSharp/BrowserContextOptions.cs
@@ -11,6 +11,19 @@ namespace PlaywrightSharp
     public class BrowserContextOptions
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="BrowserContextOptions"/> class.
+        /// </summary>
+        public BrowserContextOptions()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BrowserContextOptions"/> class.
+        /// </summary>
+        /// <param name="device">Device used to hydrate initial values.</param>
+        public BrowserContextOptions(DeviceDescriptor device) => device?.HydrateBrowserContextOptions(this);
+
+        /// <summary>
         /// Sets a consistent viewport for each page. Defaults to an 800x600 viewport. null disables the default viewport.
         /// </summary>
         public ViewportSize Viewport { get; set; } = ViewportSize.None;

--- a/src/PlaywrightSharp/DeviceDescriptor.cs
+++ b/src/PlaywrightSharp/DeviceDescriptor.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace PlaywrightSharp
 {
     /// <summary>
@@ -46,14 +48,9 @@ namespace PlaywrightSharp
                 return null;
             }
 
-            return new BrowserContextOptions()
-            {
-                UserAgent = descriptor.UserAgent,
-                Viewport = descriptor.Viewport,
-                HasTouch = descriptor.HasTouch,
-                IsMobile = descriptor.IsMobile,
-                DeviceScaleFactor = descriptor.DeviceScaleFactor,
-            };
+            var options = new BrowserContextOptions();
+            descriptor.HydrateBrowserContextOptions(options);
+            return options;
         }
 
         /// <summary>
@@ -61,5 +58,14 @@ namespace PlaywrightSharp
         /// </summary>
         /// <returns>A <see cref="BrowserContextOptions"/> with the same information as the <see cref="DeviceDescriptor"/>.</returns>
         public BrowserContextOptions ToBrowserContextOptions() => this;
+
+        internal void HydrateBrowserContextOptions(BrowserContextOptions options)
+        {
+            options.UserAgent = UserAgent;
+            options.Viewport = Viewport;
+            options.HasTouch = HasTouch;
+            options.IsMobile = IsMobile;
+            options.DeviceScaleFactor = DeviceScaleFactor;
+        }
     }
 }


### PR DESCRIPTION
This will help users to simplify `NewContextAsync` calls when starting from a device descriptor.

```cs
await using var context = await _browser.NewContextAsync(new BrowserContextOptions(Playwright.Devices["iPhone 6"])
{
    TimezoneId = "America/Jamaica",
    Locale = "fr-CH",
    UserAgent = "UA",
});
```