### PR TITLE
fix(request): make ResourceType flexible

### DIFF
--- a/src/PlaywrightSharp.Tests/Internals/FlexibleStringEnumConverterTests.cs
+++ b/src/PlaywrightSharp.Tests/Internals/FlexibleStringEnumConverterTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Runtime.Serialization;
+using System.Text.Json;
+using PlaywrightSharp.Helpers;
+using Xunit;
+
+namespace PlaywrightSharp.Tests.Internals
+{
+    public class FlexibleStringEnumConverterTests
+    {
+        private readonly JsonSerializerOptions _options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters =
+            {
+                new FlexibleStringEnumConverter<TestEnum>(TestEnum.Default)
+            },
+        };
+
+        public enum TestEnum
+        {
+            Default,
+            Document,
+            [EnumMember(Value = "usingenummember")]
+            StyleSheet,
+        }
+
+        [Fact]
+        public void ShouldWorkWithName()
+            => Assert.Equal(TestEnum.Document, JsonSerializer.Deserialize<TestEnum>("\"document\"", _options));
+
+        [Fact]
+        public void ShouldWorkWithEnumMemberName()
+            => Assert.Equal(TestEnum.StyleSheet, JsonSerializer.Deserialize<TestEnum>("\"usingenummember\"", _options));
+
+        [Fact]
+        public void ShouldFallback()
+            => Assert.Equal(TestEnum.Default, JsonSerializer.Deserialize<TestEnum>("\"foobar\"", _options));
+    }
+}

--- a/src/PlaywrightSharp.Tests/Internals/FlexibleStringEnumConverterTests.cs
+++ b/src/PlaywrightSharp.Tests/Internals/FlexibleStringEnumConverterTests.cs
@@ -6,6 +6,9 @@ using Xunit;
 
 namespace PlaywrightSharp.Tests.Internals
 {
+    /// <summary>
+    /// FlexibleStringEnumConverterTests
+    /// </summary>
     public class FlexibleStringEnumConverterTests
     {
         private readonly JsonSerializerOptions _options = new JsonSerializerOptions
@@ -25,14 +28,23 @@ namespace PlaywrightSharp.Tests.Internals
             StyleSheet,
         }
 
+        /// <summary>
+        /// Should work with the enum name.
+        /// </summary>
         [Fact]
         public void ShouldWorkWithName()
             => Assert.Equal(TestEnum.Document, JsonSerializer.Deserialize<TestEnum>("\"document\"", _options));
 
+        /// <summary>
+        /// Should work with the EnumMember value.
+        /// </summary>
         [Fact]
         public void ShouldWorkWithEnumMemberName()
             => Assert.Equal(TestEnum.StyleSheet, JsonSerializer.Deserialize<TestEnum>("\"usingenummember\"", _options));
 
+        /// <summary>
+        /// Should fallback to the default value.
+        /// </summary>
         [Fact]
         public void ShouldFallback()
             => Assert.Equal(TestEnum.Default, JsonSerializer.Deserialize<TestEnum>("\"foobar\"", _options));

--- a/src/PlaywrightSharp.Tests/Issues/Issue983.cs
+++ b/src/PlaywrightSharp.Tests/Issues/Issue983.cs
@@ -9,6 +9,9 @@ using Xunit.Abstractions;
 
 namespace PlaywrightSharp.Tests.Issues
 {
+    /// <summary>
+    /// See https://github.com/microsoft/playwright-sharp/issues/983.
+    /// </summary>
     [Collection(TestConstants.TestFixtureBrowserCollectionName)]
     public class Issue983 : PlaywrightSharpPageBaseTest
     {
@@ -17,6 +20,9 @@ namespace PlaywrightSharp.Tests.Issues
         {
         }
 
+        /// <summary>
+        /// See https://github.com/microsoft/playwright-sharp/issues/983.
+        /// </summary>
         [Fact(Timeout = PlaywrightSharp.Playwright.DefaultTimeout)]
         public async Task ShouldWork()
         {

--- a/src/PlaywrightSharp.Tests/Issues/Issue983.cs
+++ b/src/PlaywrightSharp.Tests/Issues/Issue983.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Threading.Tasks;
+using PlaywrightSharp.Tests.Attributes;
+using PlaywrightSharp.Tests.BaseTests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PlaywrightSharp.Tests.Issues
+{
+    [Collection(TestConstants.TestFixtureBrowserCollectionName)]
+    public class Issue983 : PlaywrightSharpPageBaseTest
+    {
+        /// <inheritdoc/>
+        public Issue983(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact(Timeout = PlaywrightSharp.Playwright.DefaultTimeout)]
+        public async Task ShouldWork()
+        {
+            await Page.GoToAsync("https://github.com");
+            string title = await Page.GetTitleAsync();
+            Assert.Contains("GitHub", title);
+        }
+    }
+}

--- a/src/PlaywrightSharp/Helpers/FlexibleStringEnumConverter.cs
+++ b/src/PlaywrightSharp/Helpers/FlexibleStringEnumConverter.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace PlaywrightSharp.Helpers
+{
+    internal class FlexibleStringEnumConverter<T> : JsonConverter<T>
+    {
+        private readonly Type _enumType = typeof(T);
+        private readonly Dictionary<int, EnumInfo> _rawToTransformed;
+        private readonly Dictionary<string, EnumInfo> _transformedToRaw;
+        private readonly T _default;
+
+        public FlexibleStringEnumConverter(T defaultValue)
+        {
+            _default = defaultValue;
+            string[] builtInNames = _enumType.GetEnumNames();
+            var builtInValues = _enumType.GetEnumValues();
+
+            _rawToTransformed = new Dictionary<int, EnumInfo>();
+            _transformedToRaw = new Dictionary<string, EnumInfo>();
+
+            for (int i = 0; i < builtInNames.Length; i++)
+            {
+                Enum enumValue = (Enum)builtInValues.GetValue(i);
+                int rawValue = Convert.ToInt32(enumValue);
+
+                string name = builtInNames[i];
+                var field = _enumType.GetField(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
+                var enumMemberAttribute = field.GetCustomAttribute<EnumMemberAttribute>(true);
+                string transformedName = enumMemberAttribute?.Value ?? name;
+
+                _rawToTransformed[rawValue] = new EnumInfo(transformedName, enumValue, rawValue);
+                _transformedToRaw[transformedName] = new EnumInfo(name, enumValue, rawValue);
+            }
+        }
+
+        public override bool CanConvert(Type typeToConvert) => typeof(T).IsAssignableFrom(typeToConvert);
+
+        public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var token = reader.TokenType;
+
+            if (token == JsonTokenType.String)
+            {
+                string enumString = reader.GetString();
+
+                // Case sensitive search attempted first.
+                if (_transformedToRaw.TryGetValue(enumString, out var enumInfo))
+                {
+                    return (T)Enum.ToObject(_enumType, enumInfo.RawValue);
+                }
+
+                // Case insensitive search attempted second.
+                foreach (var enumItem in _transformedToRaw)
+                {
+                    if (string.Equals(enumItem.Key, enumString, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return (T)Enum.ToObject(_enumType, enumItem.Value.RawValue);
+                    }
+                }
+            }
+
+            return _default;
+        }
+
+        public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options) => throw new NotImplementedException();
+
+        private class EnumInfo
+        {
+            public EnumInfo(string name, Enum enumValue, int rawValue)
+            {
+                Name = name;
+                EnumValue = enumValue;
+                RawValue = rawValue;
+            }
+
+            public string Name { get; set; }
+
+            public Enum EnumValue { get; set; }
+
+            public int RawValue { get; set; }
+        }
+    }
+}

--- a/src/PlaywrightSharp/Helpers/JsonExtensions.cs
+++ b/src/PlaywrightSharp/Helpers/JsonExtensions.cs
@@ -37,6 +37,7 @@ namespace PlaywrightSharp.Helpers
                 IgnoreNullValues = ignoreNullValues,
                 Converters =
                 {
+                    new FlexibleStringEnumConverter<ResourceType>(ResourceType.Unknown),
                     new JsonStringEnumMemberConverter(JsonNamingPolicy.CamelCase),
                 },
             };

--- a/src/PlaywrightSharp/ResourceType.cs
+++ b/src/PlaywrightSharp/ResourceType.cs
@@ -1,4 +1,6 @@
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+using PlaywrightSharp.Helpers;
 
 namespace PlaywrightSharp
 {
@@ -96,5 +98,15 @@ namespace PlaywrightSharp
         /// CSPViolationReport.
         /// </summary>
         CSPViolationReport,
+
+        /// <summary>
+        /// Images.
+        /// </summary>
+        Images,
+
+        /// <summary>
+        /// Beacon.
+        /// </summary>
+        Beacon,
     }
 }


### PR DESCRIPTION
I added two new enums but I made the ResourceType parsing flexible. It will default to `Unknown` if the enum item is missing.

closes #983