### PR TITLE
chore: upgrade internals libraries to .NET 5

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -22,6 +22,6 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.100
+        dotnet-version: 5.0.100
     - name: Check formatting
       run: dotnet tool update dotnet-format --add-source https://dotnet.myget.org/F/format/api/v3/index.json --tool-path ./dotnet-format/ && ./dotnet-format/dotnet-format -f ./src/ --check -v:diag

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.100
+          dotnet-version: 5.0.100
       - name: Extract Metadata
         uses: nikeee/docfx-action@v1.0.0
         with:

--- a/.github/workflows/nuget-package-tests.yml
+++ b/.github/workflows/nuget-package-tests.yml
@@ -22,14 +22,14 @@ jobs:
         if: ${{ matrix.os == 'macos-latest' }}
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.100
+          dotnet-version: 5.0.100
         env:
           DOTNET_INSTALL_DIR: /users/runner/alternate/dotnet
       - name: Setup .NET Core (Not on mac)
         if: ${{ matrix.os != 'macos-latest' }}
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.100      
+          dotnet-version: 5.0.100
       - name: Build Project
         run: dotnet build ./src/PlaywrightSharp/PlaywrightSharp.csproj -c Debug
       - name: Delete browsers on Mac

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,14 +24,14 @@ jobs:
         if: ${{ matrix.os == 'macos-latest' }}
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.100
+          dotnet-version: 5.0.100
         env:
           DOTNET_INSTALL_DIR: /users/runner/alternate/dotnet
       - name: Setup .NET Core (Not on mac)
         if: ${{ matrix.os != 'macos-latest' }}
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.100
+          dotnet-version: 5.0.100
       - name: Create Certificate
         run: |
           dotnet dev-certs https --clean
@@ -42,14 +42,14 @@ jobs:
           PRODUCT: ${{ matrix.product }}
         run: |
           dotnet build ./src/PlaywrightSharp/PlaywrightSharp.csproj -c Debug
-          dotnet test ./src/PlaywrightSharp.Tests/PlaywrightSharp.Tests.csproj -c Debug -f netcoreapp3.1 --logger "trx;LogFileName=TestResults.xml"
+          dotnet test ./src/PlaywrightSharp.Tests/PlaywrightSharp.Tests.csproj -c Debug -f net5.0 --logger "trx;LogFileName=TestResults.xml"
       - name: Run tests (Linux)
         if: ${{ matrix.os == 'ubuntu-latest' }}
         env:
           PRODUCT: ${{ matrix.product }}
         run: |
           dotnet build ./src/PlaywrightSharp/PlaywrightSharp.csproj -c Debug
-          xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- bash -c "ulimit -c unlimited && dotnet test ./src/PlaywrightSharp.Tests/PlaywrightSharp.Tests.csproj -c Debug -f netcoreapp3.1 --logger \"trx;LogFileName=TestResults.xml\""
+          xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- bash -c "ulimit -c unlimited && dotnet test ./src/PlaywrightSharp.Tests/PlaywrightSharp.Tests.csproj -c Debug -f net5.0 --logger \"trx;LogFileName=TestResults.xml\""
       - name: Test results
         uses: actions/upload-artifact@v1
         if: always()

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build-pdfdemo",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/demos/PdfDemo/bin/Debug/netcoreapp3.1/PdfDemo-Local.dll",
+            "program": "${workspaceFolder}/demos/PdfDemo/bin/Debug/net5.0/PdfDemo-Local.dll",
             "args": [],
             "cwd": "${workspaceFolder}/demos/PdfDemo",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
@@ -23,7 +23,7 @@
             "request": "launch",
             "preLaunchTask": "build-screenshotdemo",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/demos/ScreenshotsDemo/bin/Debug/netcoreapp3.1/ScreenshotsDemo-Local.dll",
+            "program": "${workspaceFolder}/demos/ScreenshotsDemo/bin/Debug/net5.0/ScreenshotsDemo-Local.dll",
             "args": [],
             "cwd": "${workspaceFolder}/demos/ScreenshotsDemo",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -59,7 +59,7 @@
                 "test",
                 "${workspaceFolder}/src/PlaywrightSharp.Tests/PlaywrightSharp.Tests.csproj",
                 "-f",
-                "netcoreapp3.1"
+                "net5.0"
             ]
         }
     ]

--- a/demos/PdfDemo/PdfDemo-Local.csproj
+++ b/demos/PdfDemo/PdfDemo-Local.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/demos/PdfDemo/PdfDemo.csproj
+++ b/demos/PdfDemo/PdfDemo.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/demos/ScreenshotsDemo/ScreenshotsDemo-Local.csproj
+++ b/demos/ScreenshotsDemo/ScreenshotsDemo-Local.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/demos/ScreenshotsDemo/ScreenshotsDemo.csproj
+++ b/demos/ScreenshotsDemo/ScreenshotsDemo.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/PlaywrightSharp.Demo/PlaywrightSharp.Demo.csproj
+++ b/src/PlaywrightSharp.Demo/PlaywrightSharp.Demo.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\PlaywrightSharp\PlaywrightSharp.csproj" />

--- a/src/PlaywrightSharp.LocalNugetTest/PlaywrightSharp.LocalNugetTest.csproj
+++ b/src/PlaywrightSharp.LocalNugetTest/PlaywrightSharp.LocalNugetTest.csproj
@@ -5,7 +5,7 @@
         <IsTestProject>true</IsTestProject>
         <LangVersion>8.0</LangVersion>
         <ReleaseVersion>0.0.0</ReleaseVersion>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="PlaywrightSharp" Version="0.160.0-alpha" />

--- a/src/PlaywrightSharp.TestServer/PlaywrightSharp.TestServer.csproj
+++ b/src/PlaywrightSharp.TestServer/PlaywrightSharp.TestServer.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
+        <TargetFrameworks>net5;net48</TargetFrameworks>
         <OutputType>Library</OutputType>
         <LangVersion>8</LangVersion>
         <ReleaseVersion>0.0.0</ReleaseVersion>

--- a/src/PlaywrightSharp.Tests/PlaywrightSharp.Tests.csproj
+++ b/src/PlaywrightSharp.Tests/PlaywrightSharp.Tests.csproj
@@ -14,9 +14,9 @@
         <NoWarn>1701;1702</NoWarn>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/PlaywrightSharp.Tests/PlaywrightSharp.Tests.csproj
+++ b/src/PlaywrightSharp.Tests/PlaywrightSharp.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
+        <TargetFrameworks>net5.0;net48</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
         <LangVersion>8.0</LangVersion>
@@ -10,7 +10,7 @@
     <Import Project="../Common/SignAssembly.props" />
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
         <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-        <DocumentationFile>bin\Debug\netcoreapp3.1\PlaywrightSharp.Tests.xml</DocumentationFile>
+        <DocumentationFile>bin\Debug\net5.0\PlaywrightSharp.Tests.xml</DocumentationFile>
         <NoWarn>1701;1702</NoWarn>
     </PropertyGroup>
     <ItemGroup>
@@ -31,11 +31,11 @@
         <ProjectReference Include="..\PlaywrightSharp.TestServer\PlaywrightSharp.TestServer.csproj" />
     </ItemGroup>
     <ItemGroup>
-      <None Remove="xunit.runner.json" />
+        <None Remove="xunit.runner.json" />
     </ItemGroup>
     <ItemGroup>
-      <Content Include="xunit.runner.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
+        <Content Include="xunit.runner.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
 </Project>

--- a/src/tools/ApiChecker/ApiChecker.csproj
+++ b/src/tools/ApiChecker/ApiChecker.csproj
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <CodeAnalysisRuleSet>../../PlaywrightSharp.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup>
-    <IsTool>true</IsTool>
-  </PropertyGroup>
-  <Import Project="../../Common/PackageInfo.props" />
-  <Import Project="../../Common/Dependencies.props" />
-  <ItemGroup>
-    <None Remove="api.json" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="api.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-    <PackageReference Include="System.CodeDom" Version="5.0.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\PlaywrightSharp\PlaywrightSharp.csproj" />
-  </ItemGroup>
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net5.0</TargetFramework>
+        <CodeAnalysisRuleSet>../../PlaywrightSharp.ruleset</CodeAnalysisRuleSet>
+    </PropertyGroup>
+    <PropertyGroup>
+        <IsTool>true</IsTool>
+    </PropertyGroup>
+    <Import Project="../../Common/PackageInfo.props" />
+    <Import Project="../../Common/Dependencies.props" />
+    <ItemGroup>
+        <None Remove="api.json" />
+    </ItemGroup>
+    <ItemGroup>
+        <Content Include="api.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
+        <PackageReference Include="System.CodeDom" Version="5.0.0" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\PlaywrightSharp\PlaywrightSharp.csproj" />
+    </ItemGroup>
 </Project>

--- a/src/tools/DriverDownloader/DriverDownloader.csproj
+++ b/src/tools/DriverDownloader/DriverDownloader.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <ReleaseVersion>0.0.0</ReleaseVersion>
     </PropertyGroup>
     <Import Project="../../Common/PackageInfo.props" />

--- a/src/tools/PlaywrightSharpTool/PlaywrightSharpTool.csproj
+++ b/src/tools/PlaywrightSharpTool/PlaywrightSharpTool.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>playwright-sharp</ToolCommandName>
         <PackageId>playwright-sharp-tool</PackageId>


### PR DESCRIPTION
I'm also upgrading the dotnet tool, but I'm still leaving the main library as a netstandard library.
 
closes #989 