### PR TITLE
codegen: ignore websocket fields

### DIFF
--- a/src/PlaywrightSharp/ElementHandle.cs
+++ b/src/PlaywrightSharp/ElementHandle.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * MIT License
  *
  * Copyright (c) 2020 Darío Kondratiuk

--- a/src/PlaywrightSharp/Frame.cs
+++ b/src/PlaywrightSharp/Frame.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * MIT License
  *
  * Copyright (c) 2020 Darío Kondratiuk

--- a/src/PlaywrightSharp/IElementHandle.cs
+++ b/src/PlaywrightSharp/IElementHandle.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * MIT License
  *
  * Copyright (c) 2020 Darío Kondratiuk

--- a/src/PlaywrightSharp/IFrame.cs
+++ b/src/PlaywrightSharp/IFrame.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * MIT License
  *
  * Copyright (c) 2020 Darío Kondratiuk

--- a/src/PlaywrightSharp/IJSHandle.cs
+++ b/src/PlaywrightSharp/IJSHandle.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
 

--- a/src/PlaywrightSharp/IPage.cs
+++ b/src/PlaywrightSharp/IPage.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * MIT License
  *
  * Copyright (c) 2020 Darío Kondratiuk

--- a/src/PlaywrightSharp/IWorker.cs
+++ b/src/PlaywrightSharp/IWorker.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;

--- a/src/PlaywrightSharp/JSHandle.cs
+++ b/src/PlaywrightSharp/JSHandle.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;

--- a/src/PlaywrightSharp/Page.cs
+++ b/src/PlaywrightSharp/Page.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * MIT License
  *
  * Copyright (c) 2020 Darío Kondratiuk

--- a/src/PlaywrightSharp/Worker.cs
+++ b/src/PlaywrightSharp/Worker.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/src/PlaywrightSharp/runtimes/expected_api_mismatch.json
+++ b/src/PlaywrightSharp/runtimes/expected_api_mismatch.json
@@ -703,6 +703,19 @@
       "justification": "We don't support this yet"
     },
     {
+      "className": "WebSocketFrameEventArgs",
+      "members": [
+        {
+          "upstreamMemberName": "binary",
+          "justification": "We are solving it a little bit different in this implementation"
+        },
+        {
+          "upstreamMemberName": "text",
+          "justification": "We are solving it a little bit different in this implementation"
+        }
+      ]
+    },
+    {
       "upstreamClassName": "browserContextOptions",
       "className": "BrowserContextOptions",
       "members": [


### PR DESCRIPTION
the api.json has some fields prepared for the new generation, ignoring them.
closes : #1163 