### PR TITLE
cache json options for perf

### DIFF
--- a/src/PlaywrightSharp/BrowserContext.cs
+++ b/src/PlaywrightSharp/BrowserContext.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;

--- a/src/PlaywrightSharp/BrowserContext.cs
+++ b/src/PlaywrightSharp/BrowserContext.cs
@@ -325,7 +325,7 @@ namespace PlaywrightSharp
             {
                 File.WriteAllText(
                     path,
-                    JsonSerializer.Serialize(state, Channel.Connection.GetDefaultJsonSerializerOptions()));
+                    JsonSerializer.Serialize(state, Channel.Connection.DefaultJsonSerializerOptions));
             }
 
             return state;

--- a/src/PlaywrightSharp/Chromium/CDPSession.cs
+++ b/src/PlaywrightSharp/Chromium/CDPSession.cs
@@ -41,7 +41,7 @@ namespace PlaywrightSharp.Chromium
         public async Task<T> SendAsync<T>(string method, object args = null)
         {
             var result = await _channel.SendAsync(method, args).ConfigureAwait(false);
-            return result == null ? default : result.Value.ToObject<T>(_connection.GetDefaultJsonSerializerOptions());
+            return result == null ? default : result.Value.ToObject<T>(_connection.DefaultJsonSerializerOptions);
         }
 
         /// <inheritdoc/>

--- a/src/PlaywrightSharp/Chromium/CDPSession.cs
+++ b/src/PlaywrightSharp/Chromium/CDPSession.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using PlaywrightSharp.Helpers;
 using PlaywrightSharp.Transport;
 using PlaywrightSharp.Transport.Channels;
-using PlaywrightSharp.Transport.Protocol;
 
 namespace PlaywrightSharp.Chromium
 {

--- a/src/PlaywrightSharp/Helpers/JsonExtensions.cs
+++ b/src/PlaywrightSharp/Helpers/JsonExtensions.cs
@@ -82,6 +82,7 @@ namespace PlaywrightSharp.Helpers
                 {
                     new FlexibleStringEnumConverter<ResourceType>(ResourceType.Unknown),
                     new JsonStringEnumMemberConverter(JsonNamingPolicy.CamelCase),
+                    new EvaluateArgumentConverter(),
                 },
             };
     }

--- a/src/PlaywrightSharp/Helpers/JsonExtensions.cs
+++ b/src/PlaywrightSharp/Helpers/JsonExtensions.cs
@@ -10,12 +10,21 @@ namespace PlaywrightSharp.Helpers
     /// </summary>
     public static class JsonExtensions
     {
-        static JsonExtensions() => DefaultJsonSerializerOptions = GetNewDefaultSerializerOptions();
+        static JsonExtensions()
+        {
+            DefaultJsonSerializerOptions = GetNewDefaultSerializerOptions();
+            DefaultIgnoreNullJsonSerializerOptions = GetNewDefaultSerializerOptions(true);
+        }
 
         /// <summary>
         /// Base serialization options used by PlaywrightSharp.
         /// </summary>
         public static JsonSerializerOptions DefaultJsonSerializerOptions { get; }
+
+        /// <summary>
+        /// Base serialization options used by PlaywrightSharp when ignoring nulls.
+        /// </summary>
+        public static JsonSerializerOptions DefaultIgnoreNullJsonSerializerOptions { get; }
 
         /// <summary>
         /// Convert a <see cref="JsonElement"/> to an object.

--- a/src/PlaywrightSharp/Response.cs
+++ b/src/PlaywrightSharp/Response.cs
@@ -77,7 +77,7 @@ namespace PlaywrightSharp
         public async Task<T> GetJsonAsync<T>(JsonSerializerOptions options = null)
         {
             string content = await GetTextAsync().ConfigureAwait(false);
-            return JsonSerializer.Deserialize<T>(content, options ?? _channel.Connection.GetDefaultJsonSerializerOptions());
+            return JsonSerializer.Deserialize<T>(content, options ?? _channel.Connection.DefaultJsonSerializerOptions);
         }
 
         /// <inheritdoc />

--- a/src/PlaywrightSharp/ScriptsHelper.cs
+++ b/src/PlaywrightSharp/ScriptsHelper.cs
@@ -23,7 +23,7 @@ namespace PlaywrightSharp
 
             if (script.IsJavascriptFunction())
             {
-                return $"({script})({string.Join(",", args.Select(a => JsonSerializer.Serialize(a, JsonExtensions.GetNewDefaultSerializerOptions())))})";
+                return $"({script})({string.Join(",", args.Select(a => JsonSerializer.Serialize(a, JsonExtensions.DefaultJsonSerializerOptions)))})";
             }
 
             if (args.Length > 0)

--- a/src/PlaywrightSharp/Transport/Channels/BrowserContextChannel.cs
+++ b/src/PlaywrightSharp/Transport/Channels/BrowserContextChannel.cs
@@ -38,7 +38,7 @@ namespace PlaywrightSharp.Transport.Channels
                         this,
                         new BindingCallEventArgs
                         {
-                            BidingCall = serverParams?.GetProperty("binding").ToObject<BindingCallChannel>(Connection.GetDefaultJsonSerializerOptions()).Object,
+                            BidingCall = serverParams?.GetProperty("binding").ToObject<BindingCallChannel>(Connection.DefaultJsonSerializerOptions).Object,
                         });
                     break;
                 case "route":
@@ -46,8 +46,8 @@ namespace PlaywrightSharp.Transport.Channels
                         this,
                         new RouteEventArgs
                         {
-                            Route = serverParams?.GetProperty("route").ToObject<RouteChannel>(Connection.GetDefaultJsonSerializerOptions()).Object,
-                            Request = serverParams?.GetProperty("request").ToObject<RequestChannel>(Connection.GetDefaultJsonSerializerOptions()).Object,
+                            Route = serverParams?.GetProperty("route").ToObject<RouteChannel>(Connection.DefaultJsonSerializerOptions).Object,
+                            Request = serverParams?.GetProperty("request").ToObject<RequestChannel>(Connection.DefaultJsonSerializerOptions).Object,
                         });
                     break;
                 case "page":
@@ -55,7 +55,7 @@ namespace PlaywrightSharp.Transport.Channels
                         this,
                         new BrowserContextPageEventArgs
                         {
-                            PageChannel = serverParams?.GetProperty("page").ToObject<PageChannel>(Connection.GetDefaultJsonSerializerOptions()),
+                            PageChannel = serverParams?.GetProperty("page").ToObject<PageChannel>(Connection.DefaultJsonSerializerOptions),
                         });
                     break;
                 case "crBackgroundPage":
@@ -63,7 +63,7 @@ namespace PlaywrightSharp.Transport.Channels
                         this,
                         new BrowserContextPageEventArgs
                         {
-                            PageChannel = serverParams?.GetProperty("page").ToObject<PageChannel>(Connection.GetDefaultJsonSerializerOptions()),
+                            PageChannel = serverParams?.GetProperty("page").ToObject<PageChannel>(Connection.DefaultJsonSerializerOptions),
                         });
                     break;
                 case "crServiceWorker":
@@ -71,7 +71,7 @@ namespace PlaywrightSharp.Transport.Channels
                         this,
                         new WorkerChannelEventArgs
                         {
-                            WorkerChannel = serverParams?.GetProperty("worker").ToObject<WorkerChannel>(Connection.GetDefaultJsonSerializerOptions()),
+                            WorkerChannel = serverParams?.GetProperty("worker").ToObject<WorkerChannel>(Connection.DefaultJsonSerializerOptions),
                         });
                     break;
             }

--- a/src/PlaywrightSharp/Transport/Channels/BrowserTypeChannel.cs
+++ b/src/PlaywrightSharp/Transport/Channels/BrowserTypeChannel.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace PlaywrightSharp.Transport.Channels

--- a/src/PlaywrightSharp/Transport/Channels/CDPSessionChannel.cs
+++ b/src/PlaywrightSharp/Transport/Channels/CDPSessionChannel.cs
@@ -26,7 +26,7 @@ namespace PlaywrightSharp.Transport.Channels
                     Disconnected?.Invoke(this, EventArgs.Empty);
                     break;
                 case "event":
-                    CDPEvent?.Invoke(this, serverParams?.ToObject<CDPEventArgs>(Connection.GetDefaultJsonSerializerOptions()));
+                    CDPEvent?.Invoke(this, serverParams?.ToObject<CDPEventArgs>(Connection.DefaultJsonSerializerOptions));
                     break;
             }
         }

--- a/src/PlaywrightSharp/Transport/Channels/CDPSessionChannel.cs
+++ b/src/PlaywrightSharp/Transport/Channels/CDPSessionChannel.cs
@@ -4,7 +4,6 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using PlaywrightSharp.Chromium;
 using PlaywrightSharp.Helpers;
-using PlaywrightSharp.Transport.Converters;
 
 namespace PlaywrightSharp.Transport.Channels
 {

--- a/src/PlaywrightSharp/Transport/Channels/FrameChannel.cs
+++ b/src/PlaywrightSharp/Transport/Channels/FrameChannel.cs
@@ -27,7 +27,6 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Text.Json;
-using System.Threading;
 using System.Threading.Tasks;
 using PlaywrightSharp.Helpers;
 using PlaywrightSharp.Input;
@@ -105,21 +104,13 @@ namespace PlaywrightSharp.Transport.Channels
             bool isPage,
             bool serializeArgument = false)
         {
-            JsonSerializerOptions serializerOptions;
-
             if (serializeArgument)
             {
-                serializerOptions = JsonExtensions.GetNewDefaultSerializerOptions(false);
                 arg = new EvaluateArgument
                 {
                     Handles = new List<EvaluateArgumentGuidElement>(),
                     Value = arg,
                 };
-                serializerOptions.Converters.Add(new EvaluateArgumentConverter());
-            }
-            else
-            {
-                serializerOptions = Connection.DefaultJsonSerializerOptions;
             }
 
             return Connection.SendMessageToServerAsync<JSHandleChannel>(
@@ -132,7 +123,7 @@ namespace PlaywrightSharp.Transport.Channels
                     ["arg"] = arg,
                     ["isPage"] = isPage,
                 },
-                serializerOptions: serializerOptions);
+                ignoreNullValues: false);
         }
 
         internal Task<JSHandleChannel> WaitForFunctionAsync(
@@ -144,21 +135,13 @@ namespace PlaywrightSharp.Transport.Channels
             int? polling,
             bool serializeArgument = false)
         {
-            JsonSerializerOptions serializerOptions;
-
             if (serializeArgument)
             {
-                serializerOptions = JsonExtensions.GetNewDefaultSerializerOptions(false);
                 arg = new EvaluateArgument
                 {
                     Handles = new List<EvaluateArgumentGuidElement>(),
                     Value = arg,
                 };
-                serializerOptions.Converters.Add(new EvaluateArgumentConverter());
-            }
-            else
-            {
-                serializerOptions = Connection.DefaultJsonSerializerOptions;
             }
 
             var args = new Dictionary<string, object>
@@ -183,7 +166,7 @@ namespace PlaywrightSharp.Transport.Channels
                 Guid,
                 "waitForFunction",
                 args,
-                serializerOptions: serializerOptions);
+                ignoreNullValues: false);
         }
 
         internal Task<JsonElement?> EvaluateExpressionAsync(
@@ -193,21 +176,13 @@ namespace PlaywrightSharp.Transport.Channels
             bool isPage,
             bool serializeArgument = false)
         {
-            JsonSerializerOptions serializerOptions;
-
             if (serializeArgument)
             {
-                serializerOptions = JsonExtensions.GetNewDefaultSerializerOptions(false);
                 arg = new EvaluateArgument
                 {
                     Handles = new List<EvaluateArgumentGuidElement>(),
                     Value = arg,
                 };
-                serializerOptions.Converters.Add(new EvaluateArgumentConverter());
-            }
-            else
-            {
-                serializerOptions = Connection.DefaultJsonSerializerOptions;
             }
 
             return Connection.SendMessageToServerAsync<JsonElement?>(
@@ -220,7 +195,7 @@ namespace PlaywrightSharp.Transport.Channels
                     ["arg"] = arg,
                     ["isPage"] = isPage,
                 },
-                serializerOptions: serializerOptions);
+                ignoreNullValues: false);
         }
 
         internal Task<JSHandleChannel> EvalOnSelectorAsync(string selector, string script, bool isFunction, object arg, bool isPage)

--- a/src/PlaywrightSharp/Transport/Channels/FrameChannel.cs
+++ b/src/PlaywrightSharp/Transport/Channels/FrameChannel.cs
@@ -50,11 +50,11 @@ namespace PlaywrightSharp.Transport.Channels
             switch (method)
             {
                 case "navigated":
-                    var e = serverParams?.ToObject<FrameNavigatedEventArgs>(Connection.GetDefaultJsonSerializerOptions());
+                    var e = serverParams?.ToObject<FrameNavigatedEventArgs>(Connection.DefaultJsonSerializerOptions);
 
                     if (serverParams.Value.TryGetProperty("newDocument", out var documentElement))
                     {
-                        e.NewDocument = documentElement.ToObject<NavigateDocument>(Connection.GetDefaultJsonSerializerOptions());
+                        e.NewDocument = documentElement.ToObject<NavigateDocument>(Connection.DefaultJsonSerializerOptions);
                     }
 
                     Navigated?.Invoke(this, e);
@@ -62,7 +62,7 @@ namespace PlaywrightSharp.Transport.Channels
                 case "loadstate":
                     LoadState?.Invoke(
                         this,
-                        serverParams?.ToObject<FrameChannelLoadStateEventArgs>(Connection.GetDefaultJsonSerializerOptions()));
+                        serverParams?.ToObject<FrameChannelLoadStateEventArgs>(Connection.DefaultJsonSerializerOptions));
                     break;
             }
         }
@@ -119,7 +119,7 @@ namespace PlaywrightSharp.Transport.Channels
             }
             else
             {
-                serializerOptions = Connection.GetDefaultJsonSerializerOptions(false);
+                serializerOptions = Connection.DefaultJsonSerializerOptions;
             }
 
             return Connection.SendMessageToServerAsync<JSHandleChannel>(
@@ -158,7 +158,7 @@ namespace PlaywrightSharp.Transport.Channels
             }
             else
             {
-                serializerOptions = Connection.GetDefaultJsonSerializerOptions(false);
+                serializerOptions = Connection.DefaultJsonSerializerOptions;
             }
 
             var args = new Dictionary<string, object>
@@ -207,7 +207,7 @@ namespace PlaywrightSharp.Transport.Channels
             }
             else
             {
-                serializerOptions = Connection.GetDefaultJsonSerializerOptions(false);
+                serializerOptions = Connection.DefaultJsonSerializerOptions;
             }
 
             return Connection.SendMessageToServerAsync<JsonElement?>(

--- a/src/PlaywrightSharp/Transport/Channels/FrameChannel.cs
+++ b/src/PlaywrightSharp/Transport/Channels/FrameChannel.cs
@@ -30,7 +30,6 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using PlaywrightSharp.Helpers;
 using PlaywrightSharp.Input;
-using PlaywrightSharp.Transport.Converters;
 
 namespace PlaywrightSharp.Transport.Channels
 {

--- a/src/PlaywrightSharp/Transport/Channels/JSHandleChannel.cs
+++ b/src/PlaywrightSharp/Transport/Channels/JSHandleChannel.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;

--- a/src/PlaywrightSharp/Transport/Channels/JSHandleChannel.cs
+++ b/src/PlaywrightSharp/Transport/Channels/JSHandleChannel.cs
@@ -49,7 +49,7 @@ namespace PlaywrightSharp.Transport.Channels
 
         internal async Task<List<JSElementProperty>> GetPropertiesAsync()
             => (await Connection.SendMessageToServerAsync(Guid, "getPropertyList", null).ConfigureAwait(false))?
-                .GetProperty("properties").ToObject<List<JSElementProperty>>(Connection.GetDefaultJsonSerializerOptions());
+                .GetProperty("properties").ToObject<List<JSElementProperty>>(Connection.DefaultJsonSerializerOptions);
 
         internal class JSElementProperty
         {

--- a/src/PlaywrightSharp/Transport/Channels/PageChannel.cs
+++ b/src/PlaywrightSharp/Transport/Channels/PageChannel.cs
@@ -103,7 +103,7 @@ namespace PlaywrightSharp.Transport.Channels
                         this,
                         new BindingCallEventArgs
                         {
-                            BidingCall = serverParams?.GetProperty("binding").ToObject<BindingCallChannel>(Connection.GetDefaultJsonSerializerOptions()).Object,
+                            BidingCall = serverParams?.GetProperty("binding").ToObject<BindingCallChannel>(Connection.DefaultJsonSerializerOptions).Object,
                         });
                     break;
                 case "route":
@@ -111,51 +111,51 @@ namespace PlaywrightSharp.Transport.Channels
                         this,
                         new RouteEventArgs
                         {
-                            Route = serverParams?.GetProperty("route").ToObject<RouteChannel>(Connection.GetDefaultJsonSerializerOptions()).Object,
-                            Request = serverParams?.GetProperty("request").ToObject<RequestChannel>(Connection.GetDefaultJsonSerializerOptions()).Object,
+                            Route = serverParams?.GetProperty("route").ToObject<RouteChannel>(Connection.DefaultJsonSerializerOptions).Object,
+                            Request = serverParams?.GetProperty("request").ToObject<RequestChannel>(Connection.DefaultJsonSerializerOptions).Object,
                         });
                     break;
                 case "popup":
                     Popup?.Invoke(this, new PageChannelPopupEventArgs
                     {
-                        Page = serverParams?.GetProperty("page").ToObject<PageChannel>(Connection.GetDefaultJsonSerializerOptions()).Object,
+                        Page = serverParams?.GetProperty("page").ToObject<PageChannel>(Connection.DefaultJsonSerializerOptions).Object,
                     });
                     break;
                 case "pageError":
-                    PageError?.Invoke(this, serverParams?.GetProperty("error").GetProperty("error").ToObject<PageErrorEventArgs>(Connection.GetDefaultJsonSerializerOptions()));
+                    PageError?.Invoke(this, serverParams?.GetProperty("error").GetProperty("error").ToObject<PageErrorEventArgs>(Connection.DefaultJsonSerializerOptions));
                     break;
                 case "fileChooser":
-                    FileChooser?.Invoke(this, serverParams?.ToObject<FileChooserChannelEventArgs>(Connection.GetDefaultJsonSerializerOptions()));
+                    FileChooser?.Invoke(this, serverParams?.ToObject<FileChooserChannelEventArgs>(Connection.DefaultJsonSerializerOptions));
                     break;
                 case "frameAttached":
-                    FrameAttached?.Invoke(this, new FrameEventArgs(serverParams?.GetProperty("frame").ToObject<FrameChannel>(Connection.GetDefaultJsonSerializerOptions()).Object));
+                    FrameAttached?.Invoke(this, new FrameEventArgs(serverParams?.GetProperty("frame").ToObject<FrameChannel>(Connection.DefaultJsonSerializerOptions).Object));
                     break;
                 case "frameDetached":
-                    FrameDetached?.Invoke(this, new FrameEventArgs(serverParams?.GetProperty("frame").ToObject<FrameChannel>(Connection.GetDefaultJsonSerializerOptions()).Object));
+                    FrameDetached?.Invoke(this, new FrameEventArgs(serverParams?.GetProperty("frame").ToObject<FrameChannel>(Connection.DefaultJsonSerializerOptions).Object));
                     break;
                 case "dialog":
-                    Dialog?.Invoke(this, new DialogEventArgs(serverParams?.GetProperty("dialog").ToObject<DialogChannel>(Connection.GetDefaultJsonSerializerOptions()).Object));
+                    Dialog?.Invoke(this, new DialogEventArgs(serverParams?.GetProperty("dialog").ToObject<DialogChannel>(Connection.DefaultJsonSerializerOptions).Object));
                     break;
                 case "console":
-                    Console?.Invoke(this, new ConsoleEventArgs(serverParams?.GetProperty("message").ToObject<ConsoleMessage>(Connection.GetDefaultJsonSerializerOptions())));
+                    Console?.Invoke(this, new ConsoleEventArgs(serverParams?.GetProperty("message").ToObject<ConsoleMessage>(Connection.DefaultJsonSerializerOptions)));
                     break;
                 case "request":
-                    Request?.Invoke(this, new RequestEventArgs { Request = serverParams?.GetProperty("request").ToObject<RequestChannel>(Connection.GetDefaultJsonSerializerOptions()).Object });
+                    Request?.Invoke(this, new RequestEventArgs { Request = serverParams?.GetProperty("request").ToObject<RequestChannel>(Connection.DefaultJsonSerializerOptions).Object });
                     break;
                 case "requestFinished":
-                    RequestFinished?.Invoke(this, serverParams?.ToObject<PageChannelRequestEventArgs>(Connection.GetDefaultJsonSerializerOptions()));
+                    RequestFinished?.Invoke(this, serverParams?.ToObject<PageChannelRequestEventArgs>(Connection.DefaultJsonSerializerOptions));
                     break;
                 case "requestFailed":
-                    RequestFailed?.Invoke(this, serverParams?.ToObject<PageChannelRequestEventArgs>(Connection.GetDefaultJsonSerializerOptions()));
+                    RequestFailed?.Invoke(this, serverParams?.ToObject<PageChannelRequestEventArgs>(Connection.DefaultJsonSerializerOptions));
                     break;
                 case "response":
-                    Response?.Invoke(this, new ResponseEventArgs { Response = serverParams?.GetProperty("response").ToObject<ResponseChannel>(Connection.GetDefaultJsonSerializerOptions()).Object });
+                    Response?.Invoke(this, new ResponseEventArgs { Response = serverParams?.GetProperty("response").ToObject<ResponseChannel>(Connection.DefaultJsonSerializerOptions).Object });
                     break;
                 case "webSocket":
-                    WebSocket?.Invoke(this, new WebSocketEventArgs { WebSocket = serverParams?.GetProperty("webSocket").ToObject<WebSocketChannel>(Connection.GetDefaultJsonSerializerOptions()).Object });
+                    WebSocket?.Invoke(this, new WebSocketEventArgs { WebSocket = serverParams?.GetProperty("webSocket").ToObject<WebSocketChannel>(Connection.DefaultJsonSerializerOptions).Object });
                     break;
                 case "download":
-                    Download?.Invoke(this, new DownloadEventArgs() { Download = serverParams?.GetProperty("download").ToObject<DownloadChannel>(Connection.GetDefaultJsonSerializerOptions()).Object });
+                    Download?.Invoke(this, new DownloadEventArgs() { Download = serverParams?.GetProperty("download").ToObject<DownloadChannel>(Connection.DefaultJsonSerializerOptions).Object });
                     break;
                 case "video":
                     Video?.Invoke(this, new VideoEventArgs() { RelativePath = serverParams?.GetProperty("relativePath").ToString() });
@@ -165,7 +165,7 @@ namespace PlaywrightSharp.Transport.Channels
                         this,
                         new WorkerChannelEventArgs
                         {
-                            WorkerChannel = serverParams?.GetProperty("worker").ToObject<WorkerChannel>(Connection.GetDefaultJsonSerializerOptions()),
+                            WorkerChannel = serverParams?.GetProperty("worker").ToObject<WorkerChannel>(Connection.DefaultJsonSerializerOptions),
                         });
                     break;
             }
@@ -304,7 +304,7 @@ namespace PlaywrightSharp.Transport.Channels
 
             if ((await Connection.SendMessageToServerAsync(Guid, "accessibilitySnapshot", args).ConfigureAwait(false)).Value.TryGetProperty("rootAXNode", out var jsonElement))
             {
-                return jsonElement.ToObject<SerializedAXNode>(Connection.GetDefaultJsonSerializerOptions());
+                return jsonElement.ToObject<SerializedAXNode>(Connection.DefaultJsonSerializerOptions);
             }
 
             return null;

--- a/src/PlaywrightSharp/Transport/Channels/WorkerChannel.cs
+++ b/src/PlaywrightSharp/Transport/Channels/WorkerChannel.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
-using PlaywrightSharp.Helpers;
-using PlaywrightSharp.Transport.Converters;
 
 namespace PlaywrightSharp.Transport.Channels
 {

--- a/src/PlaywrightSharp/Transport/Channels/WorkerChannel.cs
+++ b/src/PlaywrightSharp/Transport/Channels/WorkerChannel.cs
@@ -56,7 +56,7 @@ namespace PlaywrightSharp.Transport.Channels
             }
             else
             {
-                serializerOptions = Connection.GetDefaultJsonSerializerOptions(false);
+                serializerOptions = Connection.DefaultJsonSerializerOptions;
             }
 
             return Connection.SendMessageToServerAsync<JsonElement?>(

--- a/src/PlaywrightSharp/Transport/Channels/WorkerChannel.cs
+++ b/src/PlaywrightSharp/Transport/Channels/WorkerChannel.cs
@@ -42,21 +42,13 @@ namespace PlaywrightSharp.Transport.Channels
             object arg,
             bool serializeArgument = false)
         {
-            JsonSerializerOptions serializerOptions;
-
             if (serializeArgument)
             {
-                serializerOptions = JsonExtensions.GetNewDefaultSerializerOptions(false);
                 arg = new EvaluateArgument
                 {
                     Handles = new List<EvaluateArgumentGuidElement>(),
                     Value = arg,
                 };
-                serializerOptions.Converters.Add(new EvaluateArgumentConverter());
-            }
-            else
-            {
-                serializerOptions = Connection.DefaultJsonSerializerOptions;
             }
 
             return Connection.SendMessageToServerAsync<JsonElement?>(
@@ -68,7 +60,7 @@ namespace PlaywrightSharp.Transport.Channels
                     ["isFunction"] = isFunction,
                     ["arg"] = arg,
                 },
-                serializerOptions: serializerOptions);
+                ignoreNullValues: false);
         }
     }
 }

--- a/src/PlaywrightSharp/Transport/Connection.cs
+++ b/src/PlaywrightSharp/Transport/Connection.cs
@@ -137,7 +137,19 @@ namespace PlaywrightSharp.Transport
                     Params = args,
                 };
 
-                string messageString = JsonSerializer.Serialize(message, serializerOptions ?? DefaultIgnoreNullJsonSerializerOptions);
+                if (serializerOptions == null)
+                {
+                    if (ignoreNullValues)
+                    {
+                        serializerOptions = DefaultIgnoreNullJsonSerializerOptions;
+                    }
+                    else
+                    {
+                        serializerOptions = DefaultJsonSerializerOptions;
+                    }
+                }
+
+                string messageString = JsonSerializer.Serialize(message, serializerOptions);
                 _logger?.LogInformation($"pw:channel:command {messageString}");
 
                 return _transport.SendAsync(messageString);

--- a/src/PlaywrightSharp/Transport/Converters/EvaluateArgumentConverter.cs
+++ b/src/PlaywrightSharp/Transport/Converters/EvaluateArgumentConverter.cs
@@ -2,7 +2,6 @@ using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using PlaywrightSharp.Helpers;
-using PlaywrightSharp.Transport.Channels;
 
 namespace PlaywrightSharp.Transport.Converters
 {

--- a/src/PlaywrightSharp/Transport/Converters/EvaluateArgumentValueConverter.cs
+++ b/src/PlaywrightSharp/Transport/Converters/EvaluateArgumentValueConverter.cs
@@ -310,7 +310,7 @@ namespace PlaywrightSharp.Transport.Converters
                         return dynamicResult;
                     }
 
-                    var defaultConverter = JsonExtensions.GetNewDefaultSerializerOptions(false);
+                    var defaultConverter = JsonExtensions.DefaultJsonSerializerOptions;
                     string serialized = JsonSerializer.Serialize(dicResult, defaultConverter);
 
                     return JsonSerializer.Deserialize<T>(serialized, defaultConverter);


### PR DESCRIPTION
> If you use JsonSerializerOptions repeatedly with the same options, don't create a new JsonSerializerOptions instance each time you use it. Reuse the same instance for every call. 

https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-configure-options

Also some of the side effects:

 * https://www.meziantou.net/avoid-performance-issue-with-jsonserializer-by-reusing-the-same-instance-of-json.htm
 * https://github.com/dotnet/runtime/issues/38982#issuecomment-656491611


Note that net5 has [copy semantics for better performance](https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-configure-options?pivots=dotnet-5-0#copy-jsonserializeroptions). but that would require conditional compilation, or dropping older runtimes
