### PR TITLE
fix(postData): add more network tests

### DIFF
--- a/src/Common/PackageInfo.props
+++ b/src/Common/PackageInfo.props
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<AssemblyVersion>0.191.2</AssemblyVersion>
 		<PackageVersion>$(AssemblyVersion)</PackageVersion>
-		<DriverVersion>1.9.1-1614225150000</DriverVersion>
+		<DriverVersion>1.10.0-next-1615194558000</DriverVersion>
 		<ReleaseVersion>$(AssemblyVersion)</ReleaseVersion>
 		<FileVersion>$(AssemblyVersion)</FileVersion>
 		<NoDefaultExcludes>true</NoDefaultExcludes>

--- a/src/PlaywrightSharp.Tests/BeforeUnloadTests.cs
+++ b/src/PlaywrightSharp.Tests/BeforeUnloadTests.cs
@@ -24,8 +24,10 @@ namespace PlaywrightSharp.Tests
             // We have to interact with a page so that 'beforeunload' handlers
             // fire.
             await newPage.ClickAsync("body");
+
+            var dialogTask = newPage.WaitForEventAsync(PageEvent.Dialog);
             var pageClosingTask = newPage.CloseAsync(true);
-            var dialog = await newPage.WaitForEventAsync(PageEvent.Dialog).ContinueWith(task => task.Result.Dialog);
+            var dialog = await dialogTask.ContinueWith(task => task.Result.Dialog);
             Assert.Equal(DialogType.BeforeUnload, dialog.Type);
             Assert.Empty(dialog.DefaultValue);
             if (TestConstants.IsChromium)

--- a/src/PlaywrightSharp.Tests/BeforeUnloadTests.cs
+++ b/src/PlaywrightSharp.Tests/BeforeUnloadTests.cs
@@ -27,7 +27,7 @@ namespace PlaywrightSharp.Tests
 
             var dialogTask = newPage.WaitForEventAsync(PageEvent.Dialog);
             var pageClosingTask = newPage.CloseAsync(true);
-            var dialog = await dialogTask.ContinueWith(task => task.Result.Dialog);
+            var dialog = (await dialogTask).Dialog;
             Assert.Equal(DialogType.BeforeUnload, dialog.Type);
             Assert.Empty(dialog.DefaultValue);
             if (TestConstants.IsChromium)

--- a/src/PlaywrightSharp.Tests/BrowserContextExposeFunctionTests.cs
+++ b/src/PlaywrightSharp.Tests/BrowserContextExposeFunctionTests.cs
@@ -91,7 +91,8 @@ namespace PlaywrightSharp.Tests
 
             args.Clear();
             await page.ReloadAsync();
-            Assert.Equal(new List<object> { "context", "page" }, args);
+            Assert.Contains("context", args);
+            Assert.Contains("page", args);
         }
 
         [PlaywrightTest("browsercontext-expose-function.spec.ts", "exposeBindingHandle should work")]

--- a/src/PlaywrightSharp.Tests/BrowserContextPageEventTests.cs
+++ b/src/PlaywrightSharp.Tests/BrowserContextPageEventTests.cs
@@ -11,10 +11,10 @@ using Xunit.Abstractions;
 namespace PlaywrightSharp.Tests
 {
     [Collection(TestConstants.TestFixtureBrowserCollectionName)]
-    public class BrowserContectPageEventTests : PlaywrightSharpBrowserBaseTest
+    public class BrowserContextPageEventTests : PlaywrightSharpBrowserBaseTest
     {
         /// <inheritdoc/>
-        public BrowserContectPageEventTests(ITestOutputHelper output) : base(output)
+        public BrowserContextPageEventTests(ITestOutputHelper output) : base(output)
         {
         }
 

--- a/src/PlaywrightSharp.Tests/HarTests.cs
+++ b/src/PlaywrightSharp.Tests/HarTests.cs
@@ -93,7 +93,7 @@ namespace PlaywrightSharp.Tests
             var pageEntry = log.Pages.First();
             Assert.Equal("page_0", pageEntry.Id);
             Assert.Equal("Hello", pageEntry.Title);
-            Assert.True(pageEntry.StartedDateTime > DateTime.Now.AddMinutes(-1));
+            Assert.True(pageEntry.StartedDateTime > DateTime.UtcNow.AddMinutes(-1));
             Assert.True(pageEntry.PageTimings.OnContentLoad > 0);
             Assert.True(pageEntry.PageTimings.OnLoad > 0);
         }

--- a/src/PlaywrightSharp.Tests/NetworkPostDataTests.cs
+++ b/src/PlaywrightSharp.Tests/NetworkPostDataTests.cs
@@ -1,0 +1,120 @@
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Threading.Tasks;
+using PlaywrightSharp.Tests.BaseTests;
+using Xunit;
+using Xunit.Abstractions;
+
+
+namespace PlaywrightSharp.Tests
+{
+    /// <playwright-file>network-post-data.spec.ts</playwright-file>
+    [Collection(TestConstants.TestFixtureBrowserCollectionName)]
+    public sealed class NetworkPostDataTests : PlaywrightSharpPageBaseTest
+    {
+
+        /// <inheritdoc/>
+        public NetworkPostDataTests(ITestOutputHelper output) :
+                base(output)
+        {
+        }
+
+        /// <playwright-file>network-post-data.spec.ts</playwright-file>
+        /// <playwright-it>should return correct postData buffer for utf-8 body</playwright-it>
+        [Fact(Timeout = PlaywrightSharp.Playwright.DefaultTimeout)]
+        public async Task ShouldReturnCorrectPostdataBufferForUtf8Body()
+        {
+            await Page.GoToAsync(TestConstants.EmptyPage);
+            string value = "baẞ";
+
+            var task = Page.WaitForEventAsync(PageEvent.Request, (r) => true);
+            var actualTask = Page.EvaluateAsync(@$"() => {{
+                      const request = new Request('{TestConstants.ServerUrl + "/title.html"}', {{
+                        method: 'POST',
+                        body: JSON.stringify('{value}'),
+                      }});
+                      request.headers.set('content-type', 'application/json;charset=UTF-8');
+                      return fetch(request);
+                    }}");
+
+            Task.WaitAll(task, actualTask);
+
+            string expectedJsonValue = JsonSerializer.Serialize(value, new JsonSerializerOptions
+            {
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+                WriteIndented = true
+            });
+
+            var request = task.Result.Request;
+            Assert.Equal(expectedJsonValue, request.PostData);
+            Assert.Equal(value, request.GetPostDataJson().RootElement.GetString());
+        }
+
+        /// <playwright-file>network-post-data.spec.ts</playwright-file>
+        /// <playwright-it>should return post data w/o content-type</playwright-it>
+        [Fact(Timeout = PlaywrightSharp.Playwright.DefaultTimeout)]
+        public async Task ShouldReturnPostDataWOContentType()
+        {
+            await Page.GoToAsync(TestConstants.EmptyPage);
+
+            var task = Page.WaitForEventAsync(PageEvent.Request, (r) => true);
+            var actualTask = Page.EvaluateAsync(@"(url) => {
+                      const request = new Request(url, {
+                        method: 'POST',
+                        body: JSON.stringify({ value: 42 }),
+                      });
+                      request.headers.set('content-type', '');
+                      return fetch(request);
+                    }", TestConstants.ServerUrl + "/title.html");
+
+            Task.WaitAll(task, actualTask);
+
+            var request = task.Result.Request;
+            Assert.Equal(42, request.GetPostDataJson().RootElement.GetProperty("value").GetInt32());
+        }
+
+        /// <playwright-file>network-post-data.spec.ts</playwright-file>
+        /// <playwright-it>should throw on invalid JSON in post data</playwright-it>
+        [Fact(Timeout = PlaywrightSharp.Playwright.DefaultTimeout)]
+        public async Task ShouldThrowOnInvalidJSONInPostData()
+        {
+            await Page.GoToAsync(TestConstants.EmptyPage);
+
+            var task = Page.WaitForEventAsync(PageEvent.Request, (r) => true);
+            var actualTask = Page.EvaluateAsync(@"(url) => {
+                      const request = new Request(url, {
+                        method: 'POST',
+                        body: '<not a json>',
+                      });
+                      return fetch(request);
+                    }", TestConstants.ServerUrl + "/title.html");
+
+            Task.WaitAll(task, actualTask);
+
+            var request = task.Result.Request;
+            Assert.ThrowsAny<JsonException>(() => request.GetPostDataJson());
+        }
+
+        /// <playwright-file>network-post-data.spec.ts</playwright-file>
+        /// <playwright-it>should return post data for PUT requests</playwright-it>
+        [Fact(Timeout = PlaywrightSharp.Playwright.DefaultTimeout)]
+        public async Task ShouldReturnPostDataForPUTRequests()
+        {
+            await Page.GoToAsync(TestConstants.EmptyPage);
+
+            var task = Page.WaitForEventAsync(PageEvent.Request, (r) => true);
+            var actualTask = Page.EvaluateAsync(@"(url) => {
+                      const request = new Request(url, {
+                        method: 'PUT',
+                        body: JSON.stringify({ value: 42 }),
+                      });
+                      return fetch(request);
+                    }", TestConstants.ServerUrl + "/title.html");
+
+            Task.WaitAll(task, actualTask);
+
+            var request = task.Result.Request;
+            Assert.Equal(42, request.GetPostDataJson().RootElement.GetProperty("value").GetInt32());
+        }
+    }
+}

--- a/src/PlaywrightSharp.Tests/SelectorsTextTests.cs
+++ b/src/PlaywrightSharp.Tests/SelectorsTextTests.cs
@@ -113,13 +113,13 @@ namespace PlaywrightSharp.Tests
             Assert.Null(await Page.QuerySelectorAsync("text=\"yA\""));
         }
 
-        [PlaywrightTest("selectors-text.spec.ts", "should search for a substring")]
+        [PlaywrightTest("selectors-text.spec.ts", "should search for a substring without quotes")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
-        public async Task ShouldSearchForASubstring()
+        public async Task ShouldSearchForASubstringWithoutQuotes()
         {
             await Page.SetContentAsync("<div>textwithsubstring</div>");
             Assert.Equal("<div>textwithsubstring</div>", await Page.EvalOnSelectorAsync<string>("text=with", "e => e.outerHTML"));
-            Assert.Equal("<div>textwithsubstring</div>", await Page.EvalOnSelectorAsync<string>("text=\"with\"", "e => e.outerHTML"));
+            Assert.Null(await Page.QuerySelectorAsync("text=\"with\""));
         }
 
         [PlaywrightTest("selectors-text.spec.ts", "should skip head, script and style")]

--- a/src/PlaywrightSharp/Request.cs
+++ b/src/PlaywrightSharp/Request.cs
@@ -107,12 +107,7 @@ namespace PlaywrightSharp
                 return null;
             }
 
-            if (Headers.TryGetValue("content-type", out string contentType) && string.IsNullOrEmpty(contentType))
-            {
-                return null;
-            }
-
-            if (contentType == "application/x-www-form-urlencoded")
+            if (Headers.TryGetValue("content-type", out string contentType) && contentType == "application/x-www-form-urlencoded")
             {
                 var parsed = HttpUtility.ParseQueryString(PostData);
                 var dictionary = new Dictionary<string, string>();


### PR DESCRIPTION
- Introduces `NetworkPostDataTests`
- Ports the `postData` fix
- Moves the driver to `1.10.0-next-1615194558000`
- Fixes #1265 