### PR TITLE
chore(docs): run generator directly from msbuild

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,3 +96,13 @@ dotnet test .\src\PlaywrightSharp.sln --filter PlaywrightSharp.Tests.TapTests
 to narrow down the tests.
 
 Additionally, you can use the Test Explorer if you're using Visual Studio.
+
+### Generating the interfaces
+
+We use the [generator](https://github.com/microsoft/playwright/blob/master/utils/doclint/generateDotnetApi.js), located upstream, to generate the interfaces from the "single source of truth". To run the generator locally, you can run the following command from the **solution root**:
+
+```powershell
+dotnet msbuild -target:GenerateInterfaces .\src\Playwright\Playwright.csproj
+```
+
+Note that for this to work, the script expects the `playwright` repository, to be checked out next to `playwright-sharp`. 

--- a/src/Playwright/build/netstandard2.0/Microsoft.Playwright.targets
+++ b/src/Playwright/build/netstandard2.0/Microsoft.Playwright.targets
@@ -35,4 +35,7 @@
     <Exec Command="chmod u+x $(OutputPath)/.playwright/unix/native/node" />
     <Exec Command="chmod u+x $(OutputPath)/.playwright/unix/native/package/third_party/ffmpeg/ffmpeg-linux" />
   </Target>
+  <Target Name="GenerateInterfaces">
+    <Exec Command="node ..\playwright\utils\doclint\generateDotnetApi.js $(MSBuildProjectDirectory)/Contracts" WorkingDirectory="$(MSBuildStartupDirectory)"/>
+  </Target>
 </Project>


### PR DESCRIPTION
Adds a target to allow for faster running of interface generation. 