### PR TITLE
chore: add snk to test projects

### DIFF
--- a/src/Playwright.NUnitTest/Playwright.NUnitTest.csproj
+++ b/src/Playwright.NUnitTest/Playwright.NUnitTest.csproj
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net5.0;net48</TargetFrameworks>
+      <AssemblyName>Microsoft.Playwright.NUnitTest</AssemblyName>
+      <TargetFrameworks>netcoreapp3.1;net5.0;net48</TargetFrameworks>
     </PropertyGroup>
-    <ItemGroup>
+  <Import Project="../Common/SignAssembly.props" />
+  <ItemGroup>
         <ProjectReference Include="..\Playwright\Playwright.csproj" />
         <PackageReference Include="NUnit" Version="3.13.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />

--- a/src/Playwright.Tests.TestServer/Playwright.Tests.TestServer.csproj
+++ b/src/Playwright.Tests.TestServer/Playwright.Tests.TestServer.csproj
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.Web">
-    <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net5.0;net48</TargetFrameworks>
-        <OutputType>Library</OutputType>
-        <ReleaseVersion>0.0.0</ReleaseVersion>
-        <RootNamespace>Microsoft.Playwright.Tests.TestServer</RootNamespace>
-        <AssemblyName>Microsoft.Playwright.Tests.TestServer</AssemblyName>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
-        <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.1" />
-    </ItemGroup>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net48</TargetFrameworks>
+    <OutputType>Library</OutputType>
+    <ReleaseVersion>0.0.0</ReleaseVersion>
+    <RootNamespace>Microsoft.Playwright.Tests.TestServer</RootNamespace>
+    <AssemblyName>Microsoft.Playwright.Tests.TestServer</AssemblyName>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <Import Project="../Common/SignAssembly.props" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This removes warnings on the project about the referenced assemblies not having a strong name.