### PR TITLE
chore: clean-up & unify build/pack properties

### DIFF
--- a/.build/azure-pipeline-nuget.yml
+++ b/.build/azure-pipeline-nuget.yml
@@ -89,7 +89,7 @@ stages:
         arguments: '-c $(BuildConfiguration)'
 
     - task: DotNetCoreCLI@2
-      displayName: Pack Playwright NuGet
+      displayName: Pack Playwright.NUnit NuGet
       inputs:
         command: 'pack'
         packagesToPack: '**/Playwright.NUnit.csproj'

--- a/.build/azure-pipeline-nuget.yml
+++ b/.build/azure-pipeline-nuget.yml
@@ -128,7 +128,7 @@ stages:
       displayName: Push Playwright NuGet to NuGet.org
       inputs:
         command: 'push'
-        packagesToPush: '$(System.ArtifactsDirectory)/**/*.nupkg;!$(System.ArtifactsDirectory)/**/*.symbols.nupkg'
+        packagesToPush: '$(System.ArtifactsDirectory)/**/*.nupkg'
         nuGetFeedType: 'external'
         publishFeedCredentials: 'NuGet-Playwright'
 
@@ -152,7 +152,7 @@ stages:
       displayName: Push CLI NuGet to Nuget.org
       inputs:
         command: 'push'
-        packagesToPush: '$(System.ArtifactsDirectory)/**/*.nupkg;!$(System.ArtifactsDirectory)/**/*.symbols.nupkg'
+        packagesToPush: '$(System.ArtifactsDirectory)/**/*.nupkg'
         nuGetFeedType: 'external'
         publishFeedCredentials: 'NuGet-Playwright'
 
@@ -176,6 +176,6 @@ stages:
       displayName: Push NUnit NuGet to Nuget.org
       inputs:
         command: 'push'
-        packagesToPush: '$(System.ArtifactsDirectory)/**/*.nupkg;!$(System.ArtifactsDirectory)/**/*.symbols.nupkg'
+        packagesToPush: '$(System.ArtifactsDirectory)/**/*.nupkg'
         nuGetFeedType: 'external'
         publishFeedCredentials: 'NuGet-Playwright'

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,4 +3,13 @@
   <PropertyGroup>
     <LangVersion>9</LangVersion>
   </PropertyGroup>
+  <PropertyGroup>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
 </Project>

--- a/src/Playwright.CLI/Playwright.CLI.csproj
+++ b/src/Playwright.CLI/Playwright.CLI.csproj
@@ -22,6 +22,10 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
   <PropertyGroup>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+  <PropertyGroup>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <PackageVersion>$(AssemblyVersion)-alpha</PackageVersion>
     <ReleaseVersion>$(AssemblyVersion)</ReleaseVersion>

--- a/src/Playwright.CLI/Playwright.CLI.csproj
+++ b/src/Playwright.CLI/Playwright.CLI.csproj
@@ -18,12 +18,6 @@
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IsPackable>true</IsPackable>
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-  </PropertyGroup>
-  <PropertyGroup>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyVersion>1.0.0</AssemblyVersion>

--- a/src/Playwright.NUnit/Playwright.NUnit.csproj
+++ b/src/Playwright.NUnit/Playwright.NUnit.csproj
@@ -20,10 +20,7 @@
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
-  <PropertyGroup>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
+
   <Import Project="../Common/Version.props" />
   <Import Project="../Common/SignAssembly.props" />
   <ItemGroup>
@@ -40,9 +37,4 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
   </ItemGroup>
-  <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <Deterministic>true</Deterministic>
-  </PropertyGroup>
 </Project>

--- a/src/Playwright.NUnit/Playwright.NUnit.csproj
+++ b/src/Playwright.NUnit/Playwright.NUnit.csproj
@@ -22,6 +22,10 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
+  <PropertyGroup>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
   <Import Project="../Common/Version.props" />
   <Import Project="../Common/SignAssembly.props" />
   <ItemGroup>

--- a/src/Playwright.NUnit/Playwright.NUnit.csproj
+++ b/src/Playwright.NUnit/Playwright.NUnit.csproj
@@ -19,8 +19,6 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <IsPackable>true</IsPackable>
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
   <PropertyGroup>
     <IncludeSymbols>true</IncludeSymbols>
@@ -42,4 +40,9 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
   </ItemGroup>
+  <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
 </Project>

--- a/src/Playwright/Playwright.csproj
+++ b/src/Playwright/Playwright.csproj
@@ -21,7 +21,6 @@
     <NoWarn>1701;1702;CS0067;1734</NoWarn>
     <AssemblyName>Microsoft.Playwright</AssemblyName>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <PropertyGroup>
     <IncludeSymbols>true</IncludeSymbols>
@@ -49,9 +48,6 @@
     <None Include="Drivers\win-x64\**" Pack="true" PackagePath="Drivers\win-x64\native" />
     <None Include="Drivers\win-x86\**" Pack="true" PackagePath="Drivers\win-x86\native" />
     <None Include="build\**" Pack="true" PackagePath="build" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <DriverFiles Include="Drivers\win-x64\**">

--- a/src/Playwright/Playwright.csproj
+++ b/src/Playwright/Playwright.csproj
@@ -23,6 +23,10 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+  <PropertyGroup>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
   <Import Project="../Common/Version.props" />
   <Import Project="../Common/Dependencies.props" />
   <Import Project="../Common/SignAssembly.props" />
@@ -47,7 +51,7 @@
     <None Include="build\**" Pack="true" PackagePath="build" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <DriverFiles Include="Drivers\win-x64\**">


### PR DESCRIPTION
- Move the CI/symbols properties to the `Directory.Build.Props` file to apply it to all projects
- Generate the nupkg and snupkg and push together
- Remove the old notation of `*.Symbols.nupkg`